### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: ci
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/PandaDev0069/tuiz-backend/security/code-scanning/1](https://github.com/PandaDev0069/tuiz-backend/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the job. Since the steps in the `backend` job only check out code, set up Node, install dependencies, and run local scripts (typecheck, lint, build), they only require read access to the repository contents. The best fix is to add `permissions: contents: read` at the workflow root (after the `name` and before `on`), which will apply to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
